### PR TITLE
Add support for Netdata Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ n3tuk.
 | [`firewalld.yaml`][play-firewalld] | [`firewalld`][taskfile] | A play which will update the firewall configuration through `firewalld` on a system.                                                             |
 | [`libvirtd.yaml`][play-libvirtd]   | [`libvirtd`][taskfile]  | A play which will update the configuration of `libvirtd` on a system and prepare the Storage Pools.                                              |
 | [`cache.yaml`][play-cache]         | [`cache`][taskfile]     | A play which will update the configuration of caching proxies.                                                                                   |
+| [`netdata.yaml`][play-netdata]     | [`netdata`][taskfile]   | A play which will update the configuration of Netdata on both parent and child nodes.                                                            |
 
 All Ansible plays run via `task` can be configured with limit overrides using
 `limit=` appended after the task:
@@ -33,6 +34,7 @@ task: [bootstrap] ansible-playbook \
 [play-firewalld]: https://github.com/n3tuk/ansible/blob/main/plays/firewalld.yaml
 [play-libvirtd]: https://github.com/n3tuk/ansible/blob/main/plays/libvirtd.yaml
 [play-cache]: https://github.com/n3tuk/ansible/blob/main/plays/cache.yaml
+[play-netdata]: https://github.com/n3tuk/ansible/blob/main/plays/netdata.yaml
 [taskfile]: https://github.com/n3tuk/ansible/blob/main/Taskfile.yaml
 [inventory]: https://github.com/n3tuk/ansible/blob/main/inventory.yaml
 
@@ -62,6 +64,7 @@ task: [bootstrap] ansible-playbook \
 | [`nginx`][role-nginx]                       | A role to configure nginx on a system with standard settings, but not to configure any virtual hosts which it may serve.                                                                                      |
 | [`cache`][role-cache]                       | A role to configure a caching proxy virtual host in nginx which will proxy and cache Arch Linux repositories and packages.                                                                                    |
 | [`logrotate`][role-logrotate]               | A role to configure logrotate with sensible defaults to support the rotation and compression of historical log files.                                                                                         |
+| [`netdata`][role-netdata]                   | A role to configure netdata either as a parent node for centralised storage and processing, or a child to collect data and stream it to a parent node.                                                        |
 
 [role-filesystems]: https://github.com/n3tuk/ansible/tree/main/roles/filesystems
 [role-bootstrap]: https://github.com/n3tuk/ansible/tree/main/roles/bootstrap
@@ -85,3 +88,4 @@ task: [bootstrap] ansible-playbook \
 [role-nginx]: https://github.com/n3tuk/ansible/tree/main/roles/nginx
 [role-cache]: https://github.com/n3tuk/ansible/tree/main/roles/cache
 [role-logrotate]: https://github.com/n3tuk/ansible/tree/main/roles/logrotate
+[role-netdata]: https://github.com/n3tuk/ansible/tree/main/roles/netdata

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -253,6 +253,19 @@ tasks:
             --limit {{ .limit }} \
             --forks 3
 
+  netdata:
+    desc: Deploy the Netdata configurations for parents and children
+    silent: true
+    cmds:
+      - cmd: |-
+          ansible-playbook \
+            --syntax-check plays/netdata.yaml
+      - cmd: |-
+          ansible-playbook \
+            --ask-become-pass plays/netdata.yaml \
+            --limit {{ .limit }} \
+            --forks 5
+
   clean:
     desc: Clean up the temporary files from the repository
     summary: |

--- a/plays/baseline.yaml
+++ b/plays/baseline.yaml
@@ -20,5 +20,6 @@
     - role: sudo
     - role: users
     - role: logrotate
+    - role: netdata
   tags:
     - update

--- a/plays/group_vars/netdata.yaml
+++ b/plays/group_vars/netdata.yaml
@@ -1,1 +1,3 @@
 ---
+env_purpose: netdata-parent-node
+netdata_node_type: parent

--- a/plays/host_vars/netdata-01.d.cym-south-1.kub3.uk.yaml
+++ b/plays/host_vars/netdata-01.d.cym-south-1.kub3.uk.yaml
@@ -1,0 +1,8 @@
+---
+# Node-specific configuration for netdata-01.d.cym-south-1.kub3.uk
+
+systemd_networkd_ipv4_address: 172.23.31.6/24
+systemd_networkd_ipv4_gateway: 172.23.31.1
+systemd_networkd_ipv6_address: 2a02:8010:8006:3a31:a6:4eff:fe95:52c8/64
+
+netdata_cache_volume_size: 475G

--- a/plays/host_vars/netdata-01.p.cym-south-1.kub3.uk.yaml
+++ b/plays/host_vars/netdata-01.p.cym-south-1.kub3.uk.yaml
@@ -1,0 +1,8 @@
+---
+# Node-specific configuration for netdata-01.p.cym-south-1.kub3.uk
+
+systemd_networkd_ipv4_address: 172.23.31.5/24
+systemd_networkd_ipv4_gateway: 172.23.31.1
+systemd_networkd_ipv6_address: 2a02:8010:8006:3a31:a4:83ff:fece:564b/64
+
+netdata_cache_volume_size: 1000G

--- a/plays/host_vars/netdata-01.s.cym-south-1.kub3.uk.yaml
+++ b/plays/host_vars/netdata-01.s.cym-south-1.kub3.uk.yaml
@@ -1,0 +1,8 @@
+---
+# Node-specific configuration for netdata-01.s.cym-south-1.kub3.uk
+
+systemd_networkd_ipv4_address: 172.23.31.7/24
+systemd_networkd_ipv4_gateway: 172.23.31.1
+systemd_networkd_ipv6_address: 2a02:8010:8006:3a31:90:d4ff:feae:df72/64
+
+netdata_cache_volume_size: 225G

--- a/plays/netdata.yaml
+++ b/plays/netdata.yaml
@@ -1,0 +1,17 @@
+---
+# Configure the caching service for Arch Linux repositories
+
+- name: Configure the Netdata parent services
+  hosts: netdata
+  become: true
+  become_user: root
+  roles:
+    - role: firewalld
+    - role: netdata
+
+- name: Configure the Netdata child agents
+  hosts: all:!netdata
+  become: true
+  become_user: root
+  roles:
+    - role: netdata

--- a/roles/cache/tasks/main.yaml
+++ b/roles/cache/tasks/main.yaml
@@ -36,7 +36,7 @@
 - name: Configure the caching nginx virtual host
   ansible.builtin.template:
     src: "{{ file.name }}.jinja"
-    dest: "{{ file.dest }}/{{ file.name }}"
+    dest: "{{ file.dest }}"
     owner: root
     group: root
     mode: u=rw,g=r,o=r
@@ -46,11 +46,11 @@
     - Restart nginx
   loop:
     - name: cache.conf
-      dest: /etc/nginx/vhosts.d
+      dest: /etc/nginx/vhosts.d/cache.conf
     - name: nginx-cache
-      dest: /etc/logrotate.d
+      dest: /etc/logrotate.d/nginx-cache
   loop_control:
-    label: "{{ file.dest }}/{{ file.name }}"
+    label: "{{ file.dest }}"
     loop_var: file
   tags:
     - nginx

--- a/roles/netdata/README.md
+++ b/roles/netdata/README.md
@@ -1,0 +1,29 @@
+# n3t.uk NetData Ansible Role
+
+An Ansible role for the installation and configuration of Netdata, supporting
+either Parent nodes to collate and store data centrally, or Child nodes to
+collect the data and stream it to the parent nodes.
+
+## Requirements
+
+None other than the Ansible Role.
+
+## Role Variables
+
+None.
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+---
+- name: Install and configure netdata
+  hosts: all
+  become: true
+  become_user: root
+  roles:
+    - role: netdata
+```

--- a/roles/netdata/defaults/main.yaml
+++ b/roles/netdata/defaults/main.yaml
@@ -1,0 +1,19 @@
+---
+# defaults file for netdata
+
+netdata_api_key: parent-child-api-key
+
+netdata_node_type: child
+
+netdata_stream_port: 19999
+netdata_stream_encrypted: false
+
+netdata_cloud_claim_token:
+netdata_cloud_claim_room:
+netdata_cloud_claim_url: https://app.netdata.cloud
+
+netdata_volume_size: 64G
+
+netdata_alarm_pushover_enabled: true
+netdata_alarm_pushover_app_token:
+netdata_alarm_pushover_recipient:

--- a/roles/netdata/handlers/main.yaml
+++ b/roles/netdata/handlers/main.yaml
@@ -1,0 +1,10 @@
+---
+# handlers file for netdata
+
+- name: Restart Netdata
+  ansible.builtin.systemd_service:
+    name: netdata.service
+    state: restarted
+  tags:
+    - netdata
+    - service

--- a/roles/netdata/meta/main.yaml
+++ b/roles/netdata/meta/main.yaml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  author: Jonathan Wright
+  description: Set up and manage the netdata service for monitoring
+  company: n3tuk
+  issue_tracker_url: https://github.com/n3tuk/ansible/issues
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: ArchLinux
+      versions:
+        - all
+
+  galaxy_tags:
+    - netdata
+    - monitoring
+
+dependencies: []

--- a/roles/netdata/tasks/main.yaml
+++ b/roles/netdata/tasks/main.yaml
@@ -1,0 +1,108 @@
+---
+# tasks file for netdata
+
+# TODO: Install and start KSM via ksmd
+#   https://learn.netdata.cloud/docs/configuring/optimizing-metrics-database/database-modes-for-parent-child-setups
+
+- name: Check this role is not being run under bootstrap conditions
+  ansible.builtin.fail:
+    msg: This role does not support being run when bootstrapping hosts. Failing.
+  when: bootstrap_mount_base | default('') | length
+
+- name: Install Netdata
+  community.general.pacman:
+    name: "{{ netdata_packages }}"
+    state: latest
+  tags:
+    - netdata
+    - package
+
+- name: Prepare the filesystem for Netdata
+  ansible.builtin.include_tasks: storage.yaml
+  when: netdata_node_type == "parent"
+
+- name: Configure Netdata
+  ansible.builtin.template:
+    src: "{{ file.name }}.jinja"
+    dest: "{{ file.dest }}"
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
+  notify:
+    - Restart Netdata
+  loop:
+    - name: "{{ netdata_node_type }}.netdata.conf"
+      dest: /etc/netdata/netdata.conf
+    - name: "{{ netdata_node_type }}.stream.conf"
+      dest: /etc/netdata/stream.conf
+    - name: netdata
+      dest: /etc/logrotate.d/netdata
+  loop_control:
+    label: "{{ file.dest }}"
+    loop_var: file
+  tags:
+    - nginx
+    - configuraton
+
+- name: Configure Netdata alerting
+  ansible.builtin.template:
+    src: "{{ file.name }}.jinja"
+    dest: "{{ file.dest }}"
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
+  when: netdata_node_type == "parent"
+  notify:
+    - Restart Netdata
+  loop:
+    - name: health_alarm_notify.conf
+      dest: /etc/netdata/health_alarm_notify.conf
+  loop_control:
+    label: "{{ file.dest }}"
+    loop_var: file
+  tags:
+    - nginx
+    - configuraton
+
+- name: Add the Netdata service to the internal zone
+  ansible.posix.firewalld:
+    zone: internal
+    service: "{{ service }}"
+    permanent: false
+    immediate: true
+    state: enabled
+  when: netdata_node_type == "parent"
+  loop:
+    - netdata-dashboard
+  loop_control:
+    label: "{{ service }}"
+    loop_var: service
+  notify:
+    - Run firewall-cmd --runtime-to-permanent
+  tags:
+    - netdata
+    - firewall
+
+- name: Ensure Netdata is enabled
+  ansible.builtin.systemd_service:
+    name: netdata.service
+    enabled: true
+    state: started
+  tags:
+    - netdata
+    - service
+
+- name: Claim node in Netdata Cloud
+  ansible.builtin.shell: # noqa no-changed-when
+    cmd: |-
+      netdata-claim.sh \
+        -token={{ netdata_cloud_claim_token }} \
+        -rooms={{ netdata_cloud_claim_room }} \
+        -url={{ netdata_cloud_claim_url }}
+    creates: /var/lib/netdata/cloud.d/claimed_id
+  when: netdata_node_type == "parent"
+  notify:
+    - Restart Netdata
+  tags:
+    - netdata
+    - service

--- a/roles/netdata/tasks/storage.yaml
+++ b/roles/netdata/tasks/storage.yaml
@@ -1,0 +1,34 @@
+---
+# storage tasks for netdata
+
+- name: Create the logical volume for Netdata
+  community.general.lvol:
+    vg: "{{ netdata_volume_group }}"
+    lv: "{{ netdata_volume_name }}"
+    size: "{{ netdata_volume_size }}"
+  ignore_errors: "{{ ansible_check_mode }}"
+  tags:
+    - netdata
+    - filesystem
+
+- name: Create the Netdata volume filesystem
+  community.general.filesystem:
+    device: "/dev/{{ netdata_volume_group }}/{{ netdata_volume_name }}"
+    fstype: ext4
+    opts: "{{ netdata_volume_options | default(omit) }}"
+    state: present
+  ignore_errors: "{{ ansible_check_mode }}"
+  tags:
+    - netdata
+    - filesystem
+
+- name: Register and mount the Netdata volume
+  ansible.posix.mount:
+    src: "/dev/{{ netdata_volume_group }}/{{ netdata_volume_name }}"
+    path: "{{ netdata_volume_path }}"
+    fstype: ext4
+    opts: defaults,rw,noatime,nosuid,noexec,nodev
+    state: mounted
+  tags:
+    - netdata
+    - filesystems

--- a/roles/netdata/templates/child.netdata.conf.jinja
+++ b/roles/netdata/templates/child.netdata.conf.jinja
@@ -1,0 +1,24 @@
+# {{ ansible_managed }}
+
+# This is a client node meaning that the service will only collect data and
+# forward it onto a parent node for storage, processing, and alerting
+
+[global]
+  run as user = netdata
+
+  # Disable the local database as this is a client node which will forward
+  # metrics onto the parent node(s) defined in the stream.conf file
+  memory mode = none
+
+[web]
+  # Disable the web interface for this node as the data will be streamed to the
+  # parent node and then viewed in the NetData Dashboard at app.netdata.cloud
+  mode = none
+
+[ml]
+  # As no data is saved locally, disable the Machine Learning functions
+  enabled = no
+
+[health]
+  # As no data is saved locally, do not process alerts for this node
+  enabled = no

--- a/roles/netdata/templates/child.stream.conf.jinja
+++ b/roles/netdata/templates/child.stream.conf.jinja
@@ -1,0 +1,22 @@
+# {{ ansible_managed }}
+
+# This is a client node meaning that the service will only collect data and
+# forward it onto a parent node for storage, processing, and alerting
+
+[stream]
+  # Send all available metrics from this client node to a parent node as the
+  # destination for storage and processing of alerts
+  enabled = yes
+  destination = tcp:netdata-01.{{ env_name[:1] }}.{{ env_location }}.kub3.uk:{{ netdata_stream_port }}{% if netdata_stream_encrypted %}:SSL{% endif %}
+
+  api key = {{ netdata_api_key }}
+  send charts matching = *
+
+  timeout seconds = 10
+  reconnect delay seconds = 3
+
+  # Enable compression of the data from the client end, and allow up to 25MB of
+  # data to be buffered (about two minutes worth) to allow the parent to be
+  # updated and/or restarted
+  enable compression = yes
+  buffer size bytes = 26214400

--- a/roles/netdata/templates/health_alarm_notify.conf.jinja
+++ b/roles/netdata/templates/health_alarm_notify.conf.jinja
@@ -1,0 +1,69 @@
+# For ISO 8601 dates, use '+%FT%T%z'
+# For RFC 5322 dates, use '+%a, %d %b %Y %H:%M:%S %z'
+# For RFC 3339 dates, use '+%F %T%:z'
+# For RFC 1123 dates, use '+%a, %d %b %Y %H:%M:%S %Z'
+# For RFC 1036 dates, use '+%A, %d-%b-%y %H:%M:%S %Z'
+# For a reasonably local date and time (in that order), use '+%x %X'
+# For the old default behavior (compatible with ANSI C's asctime() function), leave this empty.
+date_format='+%FT%T%z'
+use_fqdn='YES'
+
+SEND_EMAIL="NO"
+SEND_DYNATRACE="NO"
+SEND_GOTIFY="NO"
+SEND_OPSGENIE="NO"
+SEND_PUSHBULLET="NO"
+SEND_TWILIO="NO"
+SEND_MESSAGEBIRD="NO"
+SEND_KAVENEGAR="NO"
+SEND_SLACK="NO"
+SEND_MSTEAMS="NO"
+SEND_ROCKETCHAT="NO"
+SEND_ALERTA="NO"
+SEND_FLOCK="NO"
+SEND_HIPCHAT="NO"
+SEND_KAFKA="NO"
+SEND_PD="NO"
+SEND_FLEEP="NO"
+SEND_IRC="NO"
+SEND_SYSLOG="NO"
+SEND_PROWL="NO"
+SEND_AWSSNS="NO"
+SEND_SMS="NO"
+SEND_CUSTOM="NO"
+
+#------------------------------------------------------------------------------
+# pushover (pushover.net) global notification options
+SEND_PUSHOVER="{% if netdata_alarm_pushover_enabled %}YES{% else %}NO{% endif %}"
+PUSHOVER_APP_TOKEN="{{ netdata_alarm_pushover_app_token }}"
+DEFAULT_RECIPIENT_PUSHOVER="{{ netdata_alarm_pushover_recipient }}"
+
+#------------------------------------------------------------------------------
+# telegram (telegram.org) global notification options
+SEND_TELEGRAM="NO"
+TELEGRAM_RETRIES_ON_LIMIT="3"
+
+# Contact the bot @BotFather to create a new bot and receive a bot token.
+# Without it, netdata cannot send telegram messages.
+TELEGRAM_BOT_TOKEN=""
+
+# To get your chat ID send the command /getid to telegram bot @myidbot
+# (https://t.me/myidbot). Each user also needs to open a conversation with the
+# bot that will be sending notifications.
+# If a role's recipients are not configured, a message will be sent to
+# this chat id (empty = do not send a notification for unconfigured roles):
+DEFAULT_RECIPIENT_TELEGRAM=""
+
+#------------------------------------------------------------------------------
+# discord (discord.com) global notification options
+SEND_DISCORD="NO"
+DISCORD_WEBHOOK_URL=""
+DEFAULT_RECIPIENT_DISCORD=""
+
+#------------------------------------------------------------------------------
+# ntfy.sh global notification options
+SEND_NTFY="NO"
+NTFY_USERNAME=""
+NTFY_PASSWORD=""
+NTFY_ACCESS_TOKEN=""
+DEFAULT_RECIPIENT_NTFY=""

--- a/roles/netdata/templates/netdata.jinja
+++ b/roles/netdata/templates/netdata.jinja
@@ -1,0 +1,30 @@
+# {{ ansible_managed }}
+
+# Log rotation support for the netdata service on both clients and parents.
+
+/var/log/netdata/*.log {
+  # Rotate these log files every day and keep up to 14 days worth; if they are
+  # missing just skip and carry on
+  daily
+  missingok
+  rotate 14
+
+  # Use date-based extension for the rotated log file, rather than numeric, to
+  # make it easier to see what days the log files are referencing, especially if
+  # there are days without log files
+  dateext
+  dateformat .%Y%m%d
+
+  # Compress the log files once rotated by delayed by one (by gzip with .gz
+  # extension by default)
+  delaycompress
+  compress
+
+  # Run the pre- and post-rotation commands once when all log files are
+  # processed, rather than once per file, which in this case is just to pass the
+  # HUP signal to netdata
+  sharedscripts
+  postrotate
+    /bin/kill -HUP `cat /run/netdata/netdata.pid 2>/dev/null` 2>/dev/null || true
+  endscript
+}

--- a/roles/netdata/templates/parent.netdata.conf.jinja
+++ b/roles/netdata/templates/parent.netdata.conf.jinja
@@ -1,0 +1,37 @@
+# {{ ansible_managed }}
+
+# This is a parent node which will collect data from child nodes using the
+# following API key, locally storing that data and processing/alerting on it
+
+[global]
+  run as user = netdata
+
+[db]
+  mode = dbengine
+  storage tiers = 3
+
+  # To allow memory pressure to offload index from ram
+  dbengine page descriptors in file mapped memory = yes
+
+  # Storage Tier 0
+  update every = 1 # 1 Second
+  # Provide 14 days of 1s metrics
+  #   (9500 x 1byte x 86400 seconds) = 765MB per day
+  dbengine multihost disk space MB = 10240
+  dbengine page cache size MB = 512
+
+  # Storage Tier 1
+  dbengine tier 1 update every iterations = 60 # 60 Seconds
+  # Provide 90 days of 1m metrics
+  #   (9500 x 4byte x 1440 minutes) = 50MB per day
+  dbengine tier 1 multihost disk space MB = 5120
+  dbengine tier 1 page cache size MB = 32
+  dbengine tier 1 backfill = new
+
+  # Storage Tier 2
+  dbengine tier 2 update every iterations = 60 # 3600 Seconds
+  # Provide 365 days of 5m metrics
+  #   (9500 x 4byte x 288 x 5 minutes) = 10MB per day
+  dbengine tier 2 multihost disk space MB = 4096
+  dbengine tier 2 page cache size MB = 32
+  dbengine tier 2 backfill = new

--- a/roles/netdata/templates/parent.stream.conf.jinja
+++ b/roles/netdata/templates/parent.stream.conf.jinja
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+
+# This is a parent node which will collect data from child nodes using the
+# following API key, locally storing that data and processing/alerting on it
+
+[{{ netdata_api_key }}]
+  enabled = yes
+  allow_from = 172.23.*.*
+  multiple connections = allow
+  enable compression = yes
+
+  default memory mode = dbengine
+
+  # alerts checks, only while the child is connected
+  health enabled by default = auto
+  default postpone alarms on connect seconds = 60

--- a/roles/netdata/vars/main.yaml
+++ b/roles/netdata/vars/main.yaml
@@ -1,0 +1,11 @@
+---
+# vars file for netdata
+
+netdata_packages:
+  - netdata
+  - netdata-go-plugins
+
+netdata_volume_path: /var/cache/netdata
+netdata_volume_group: storage
+netdata_volume_name: netdata
+netdata_volume_options: "-L NETDATA"

--- a/roles/nginx/tasks/main.yaml
+++ b/roles/nginx/tasks/main.yaml
@@ -31,10 +31,27 @@
     - nginx
     - configuration
 
+- name: Configure the nginx logging directories
+  ansible.builtin.file:
+    path: "/var/log/{{ directory }}"
+    owner: root
+    group: root
+    mode: u=rwx,g=rx,o=rx
+    state: directory
+  loop:
+    - nginx
+    - nginx/localhost
+  loop_control:
+    label: "/var/log/{{ directory }}"
+    loop_var: directory
+  tags:
+    - nginx
+    - configuration
+
 - name: Configure nginx
   ansible.builtin.template:
     src: "{{ file.name }}.jinja"
-    dest: "{{ file.dest }}/{{ file.name }}"
+    dest: "{{ file.dest }}"
     owner: root
     group: root
     mode: u=rw,g=r,o=r
@@ -42,15 +59,19 @@
     - Restart nginx
   loop:
     - name: nginx.conf
-      dest: /etc/nginx
+      dest: /etc/nginx/nginx.conf
     - name: mime.types
-      dest: /etc/nginx
+      dest: /etc/nginx/mime.types
     - name: json-logging.conf
-      dest: /etc/nginx/conf.d
+      dest: /etc/nginx/conf.d/json-logging.conf
+    - name: localhost.conf
+      dest: /etc/nginx/vhosts.d/localhost.conf
+    - name: netdata.conf
+      dest: /etc/netdata/go.d/nginx.conf
     - name: nginx
-      dest: /etc/logrotate.d
+      dest: /etc/logrotate.d/nginx
   loop_control:
-    label: "{{ file.dest }}/{{ file.name }}"
+    label: "{{ file.dest }}"
     loop_var: file
   tags:
     - nginx

--- a/roles/nginx/templates/localhost.conf.jinja
+++ b/roles/nginx/templates/localhost.conf.jinja
@@ -1,0 +1,43 @@
+# {{ ansible_managed }}
+
+# A virtual host to provide access to the status page for netdata collection
+
+server {
+  server_name
+    localhost;
+
+  listen 127.0.0.1:80;
+  listen [::1]:80;
+
+  # Don't try and compress anything managed by this virtual host as it will all
+  # be packages which are compressed already, so won't save space or bandwidth
+  gzip off;
+
+  # Block dot files from being serviced, including the .well-known directory,
+  # regardless of whether anything exists or not
+  location ~ /\.(?!well-known) {
+    deny all;
+  }
+
+  # This is just a basic website for proxying requests and caching the files, so
+  # disable anything other than GET and HEAD from being accepted.
+  if ($request_method !~ ^(GET|HEAD)$) {
+    return '405';
+  }
+
+  # Set the logs for this virtual host, using JSON-based logging for requests
+  access_log /var/log/nginx/localhost/access.log json-combined buffer=512k flush=1m;
+  error_log  /var/log/nginx/localhost/error.log warn;
+
+  location = /status {
+    stub_status;
+  }
+
+  location = /favicon.ico {
+    log_not_found off;
+  }
+
+  location = /robots.txt {
+    log_not_found off;
+  }
+}

--- a/roles/nginx/templates/netdata.conf.jinja
+++ b/roles/nginx/templates/netdata.conf.jinja
@@ -1,0 +1,3 @@
+jobs:
+  - name: cache
+    url: http://127.0.0.1/status


### PR DESCRIPTION
Add a role which will deploy and configure Netdata for the monitoring of all servers in the Lab environment. This will set up three sets of parent nodes (one for each environment) and then set up all currently known child nodes to monitor their own data and then forward it to parent node.

The parent nodes are set up with firewall rules for inbound traffic, and local filesystem updates for storage. The nginx role is also updated to support the configuration of monitoring against it by Netdata.

## Checklist

Please confirm the following checks:

- [x] My pull request follows the guidelines set out in `CONTRIBUTING.md`.
- [x] I have performed a self-review of my code and run any tests locally to check.
- [ ] I have added tests that prove my changes are effective and work correctly.
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my code and corrected any misspellings.
- [x] Each commit in this pull request has a meaningful subject & body for context.
- [x] I have squashed all "fix(up)" commits to provide a clean code history.
- [x] My pull request has an appropriate title and description for context.
- [ ] I have linked this pull request to other issues or pull requests as needed.
- [x] I have added `type/...`, `changes/...`, and 'release/...' labels as needed.
