### PR TITLE
OP-9 Add the missing `dns` Ansible Play and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ n3tuk.
 | [`upgrade.yaml`][play-upgrade]     | [`upgrade`][taskfile]        | A play which will update and upgrade all Arch Linux packages of using `pacman`.                                                                  |
 | [`authentik.yaml`][play-authentik] | [`play:authentik`][taskfile] | A play which will deploy and configure the Authentik identity provider alongside PostgreSQL, `cloudflared`, and Tailscale.                       |
 | [`ca.yaml`][play-ca]               | [`play:ca`][taskfile]        | A play which will deploy and configure the `step-ca` Certificate Authority alongside PostgreSQL and Tailscale.                                   |
+| [`dns.yaml`][play-dns]             | [`play:dns`][taskfile]       | A play which will deploy and configure the `bind` DNS service.                                                                                   |
 
 All Ansible plays run via `task` can be configured with limit overrides using
 `limit=` appended after the task:
@@ -34,6 +35,7 @@ task: [bootstrap] ansible-playbook \
 [play-users]: https://github.com/n3tuk/ansible/blob/main/plays/users.yaml
 [play-authentik]: https://github.com/n3tuk/ansible/blob/main/plays/authentik.yaml
 [play-ca]: https://github.com/n3tuk/ansible/blob/main/plays/ca.yaml
+[play-dns]: https://github.com/n3tuk/ansible/blob/main/plays/dns.yaml
 [taskfile]: https://github.com/n3tuk/ansible/blob/main/Taskfile.yaml
 [inventory]: https://github.com/n3tuk/ansible/blob/main/inventory.yaml
 
@@ -72,6 +74,7 @@ task: [bootstrap] ansible-playbook \
 | [`postgresql`][role-postgresql]             | A role to install and configure PostgreSQL on a virtual machine to manage relational databases.                                                                                                               |
 | [`valkey`][role-valkey]                     | A role to install and configure Valkey on a virtual machine to manage in-memory data structures.                                                                                                              |
 | [`stepca`][role-stepca]                     | A role to install and configure `step-ca` on a virtual machine to provide Certificate Authority services.                                                                                                     |
+| [`bind`][role-bind]                         | A role to install and configure `bind` on a virtual machine to provide DNS services based on view configurations.                                                                                             |
 
 [role-filesystems]: https://github.com/n3tuk/ansible/tree/main/roles/filesystems
 [role-bootstrap]: https://github.com/n3tuk/ansible/tree/main/roles/bootstrap
@@ -104,3 +107,4 @@ task: [bootstrap] ansible-playbook \
 [role-postgresql]: https://github.com/n3tuk/ansible/tree/main/roles/postgresql
 [role-valkey]: https://github.com/n3tuk/ansible/tree/main/roles/valkey
 [role-stepca]: https://github.com/n3tuk/ansible/tree/main/roles/stepca
+[role-bind]: https://github.com/n3tuk/ansible/tree/main/roles/bind

--- a/plays/dns.yaml
+++ b/plays/dns.yaml
@@ -1,0 +1,15 @@
+---
+- name: Configure DNS Hosts
+  hosts: dns
+  become: true
+  become_user: root
+  roles:
+    - role: ufw
+      tags:
+        - ufw
+    - role: bind
+      tags:
+        - bind
+    - role: tailscale
+      tags:
+        - tailscale


### PR DESCRIPTION
Add in the missing `dns` Ansible Play, which was not committed with the Ansible Role in #29, along with the documentation on the play and role in the root `README.md`.

## Checklist

Before raising this Pull Request, please review the `CONTRIBUTING.md` document for guidance on how best to work with this repository and its code. Additionally, please review and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests to check
- [ ] I have run and added tests to prove my changes are effective and correctly
- [ ] I have made corresponding changes to the documentation as needed
- [x] Each commit in, and this PR, have a meaningful subject and body for context
- [x] I have added `release/...` and `{update,type}/...` labels to this PR
