### PR TITLE
fix: Fix the Lego scripts for certificate management

### DIFF
--- a/roles/lego/templates/run.sh.jinja
+++ b/roles/lego/templates/run.sh.jinja
@@ -19,29 +19,19 @@ for domain in ${LEGO_CERT_DOMAINS}; do
   LEGO_CERT_DOMAIN_ARGS+="--domains ${domain}"
 done
 
-# Test that the account has been set up and the initial certificate obtained,
-# and if not, we'll need to complete the initial run rather than a renewal
+LEGO_RENEW_TYPE="Renewing"
 if [[ ! -f "{{ lego_lib_path }}/${LEGO_CERT_GROUP}/accounts/${LEGO_ACME_SERVER_DOMAIN}/${LEGO_ACME_EMAIL}/account.json" ||
   ! -f "{{ lego_lib_path }}/${LEGO_CERT_GROUP}/certificates/${LEGO_CERT_FIRST_DOMAIN}.crt" ]]; then
-  echo "$(date +'%Y/%m/%d %H:%M:%S') [INFO] Creating new certificate for ${LEGO_CERT_GROUP} (${LEGO_CERT_DOMAINS// /, /})"
-  /usr/bin/lego \
-    --accept-tos --email "${LEGO_ACME_EMAIL}" \
-    --path "/var/lib/lego/${LEGO_CERT_GROUP}" \
-    --server "${LEGO_ACME_SERVER}" \
-    --key-type "${LEGO_CERT_KEY_TYPE}" \
-    --http --http.${LEGO_ACME_MODE} \
-    ${LEGO_CERT_DOMAIN_ARGS} \
-    run --run-hook="${LEGO_RENEW_HOOK}"
-else
-  echo "$(date +'%Y/%m/%d %H:%M:%S') [INFO] Renewing certificate for ${LEGO_CERT_GROUP} (${LEGO_CERT_DOMAINS// /, /})"
-  /usr/bin/lego \
-    --accept-tos --email "${LEGO_ACME_EMAIL}" \
-    --path "/var/lib/lego/${LEGO_CERT_GROUP}" \
-    --server "${LEGO_ACME_SERVER}" \
-    --key-type "${LEGO_CERT_KEY_TYPE}" \
-    --http --http.${LEGO_ACME_MODE} \
-    ${LEGO_CERT_DOMAIN_ARGS} \
-    renew --days 2 \
-    --no-random-sleep \
-    --renew-hook="${LEGO_RENEW_HOOK}"
+  LEGO_RENEW_TYPE="Obtaining initial"
 fi
+
+echo "$(date +'%Y/%m/%d %H:%M:%S') [INFO] ${LEGO_RENEW_TYPE} certificate for ${LEGO_CERT_GROUP} (${LEGO_CERT_DOMAINS// /, })"
+
+/usr/bin/lego run \
+  --accept-tos --email "${LEGO_ACME_EMAIL}" \
+  --path "/var/lib/lego/${LEGO_CERT_GROUP}" \
+  --server "${LEGO_ACME_SERVER}" \
+  --key-type "${LEGO_CERT_KEY_TYPE}" \
+  --http --http.${LEGO_ACME_MODE} \
+  ${LEGO_CERT_DOMAIN_ARGS} \
+  --deploy-hook="${LEGO_RENEW_HOOK}"

--- a/roles/postgresql/templates/lego.sh.jinja
+++ b/roles/postgresql/templates/lego.sh.jinja
@@ -4,18 +4,18 @@
 set -euo pipefail
 
 # Ensure required environment variables are set
-: "${LEGO_CERT_PATH:?LEGO_CERT_PATH must be set}"
-: "${LEGO_CERT_KEY_PATH:?LEGO_CERT_KEY_PATH must be set}"
+: "${LEGO_HOOK_CERT_PATH:?LEGO_HOOK_CERT_PATH must be set}"
+: "${LEGO_HOOK_CERT_KEY_PATH:?LEGO_HOOK_CERT_KEY_PATH must be set}"
 
 # Check if certificate files exist
-if [[ ! -f "${LEGO_CERT_PATH}" || ! -f "${LEGO_CERT_KEY_PATH}" ]]; then
+if [[ ! -f "${LEGO_HOOK_CERT_PATH}" || ! -f "${LEGO_HOOK_CERT_KEY_PATH}" ]]; then
   echo "$(date +'%Y/%m/%d %H:%M:%S') [ERROR] Certificate files not found. Cannot continue." >&2
   exit 1
 fi
 
 for cert in \
-  "${LEGO_CERT_PATH}={{ postgresql_data_path }}/server.crt" \
-  "${LEGO_CERT_KEY_PATH}={{ postgresql_data_path }}/server.key"; do
+  "${LEGO_HOOK_CERT_PATH}={{ postgresql_data_path }}/server.crt" \
+  "${LEGO_HOOK_CERT_KEY_PATH}={{ postgresql_data_path }}/server.key"; do
   tmp="${cert/*=/}.tmp.${$}"
 
   echo "$(date +'%Y/%m/%d %H:%M:%S') [INFO] Copying ${cert/=*/} to ${cert/*=/} (via ${tmp})"


### PR DESCRIPTION
The `v5.x` release of Lego has a different process for handling certificates. Specifically, the renew command is now redundant, and only run is needed. Additionally, the old hooks have been refactored. These changes take these into account and fix the scripts to support the new release.

## Checklist

Before raising this Pull Request, please review the `CONTRIBUTING.md` document for guidance on how best to work with this repository and its code. Additionally, please review and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests to check
- [ ] I have run and added tests to prove my changes are effective and correctly
- [ ] I have made corresponding changes to the documentation as needed
- [x] Each commit in, and this PR, have a meaningful subject and body for context
- [x] I have added `release/...` and `{update,type}/...` labels to this PR
