### PR TITLE
fix: Add IPv6-only Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This is the parent configuration within this repository
+root = true
+
+[*]
+charset = utf-8
+# Always use with unix-based endings and ensure all files have a new-line only
+# at the end of the file (this can occasionally cause issues with some file
+# processing if not present)
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+# Prefer space-based indentations
+indent_style = space
+indent_size = 2
+tab_width = 2
+
+[*.py]
+# Override indents for Python files as this is required by the language syntax
+indent_size = 4
+
+[*.yaml]
+# Prefer double quotes where possible for YAML files for consistency in keeping
+# with general Ansible guidelines
+quote_type = double

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         name: Check all files end in a new-line only
 
   - repo: https://github.com/zricethezav/gitleaks.git
-    rev: v8.29.0
+    rev: v8.30.0
     hooks:
       - id: gitleaks
         name: Check for hard-coded secrets, keys, and credentials
@@ -49,7 +49,7 @@ repos:
           - -sr
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.37.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         name: Lint YAML files for correctness and formatting
@@ -58,7 +58,7 @@ repos:
           - .yamllint.yaml
 
   - repo: https://github.com/python-jsonschema/check-jsonschema.git
-    rev: 0.34.1
+    rev: 0.37.3
     hooks:
       - name: Check the Dependabot configuration for correctness
         id: check-dependabot
@@ -66,7 +66,7 @@ repos:
         id: check-github-workflows
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v25.9.2
+    rev: v26.4.0
     hooks:
       - id: ansible-lint
         name: Lint Ansible files for correctness and formatting
@@ -76,7 +76,7 @@ repos:
           - ansible
 
   - repo: https://github.com/igorshubovych/markdownlint-cli.git
-    rev: v0.45.0
+    rev: v0.49.0
     hooks:
       - id: markdownlint
         name: Check Markdown correctness and formatting

--- a/inventory.yaml
+++ b/inventory.yaml
@@ -8,6 +8,7 @@ all:
     cache:
     netdata:
     manager:
+    test:
 
 development:
   hosts:
@@ -23,6 +24,7 @@ services:
     cache:
     netdata:
     manager:
+    test:
 
 proxmox:
   hosts:
@@ -53,6 +55,10 @@ netdata:
   hosts:
     netdata-[01:02].services.n3t.uk:
 
+test:
+  hosts:
+    cynon.bridgend.n3t.uk:
+
 arch:
   children:
     authentik:
@@ -60,6 +66,7 @@ arch:
     ca:
     cache:
     netdata:
+    test:
 
 debian:
   children:
@@ -84,6 +91,7 @@ virtual:
     cache:
     netdata:
     manager:
+    test:
 
 physical:
   children:

--- a/plays/host_vars/cynon.bridgend.n3t.uk.yaml
+++ b/plays/host_vars/cynon.bridgend.n3t.uk.yaml
@@ -1,0 +1,80 @@
+---
+env_purpose: ipv6-only-node
+
+filesystems_physical_drives:
+  - vda
+
+filesystems_volume_groups:
+  - name: storage
+    partitions:
+      - /dev/vda2
+
+filesystems_physical_partitions:
+  - name: ESP
+    device: vda
+    number: 1
+    path: /efi
+    start: 1MiB
+    end: 256MiB
+    flags:
+      - esp
+    pv_type: fat32
+    fs_type: vfat
+    fs_opts: -F 32 -n ESP
+  - name: LVM
+    device: vda
+    number: 2
+    start: 256MiB
+    end: 100%
+    flags:
+      - lvm
+
+filesystems_logical_volumes:
+  - name: system
+    group: storage
+    path: /
+    size: 8G
+    fs_type: ext4
+    fs_opts: -L SYSTEM
+  - name: swap
+    group: storage
+    size: 1G
+    fs_type: swap
+    fs_opts: -L SWAP
+  - name: journald
+    group: storage
+    path: /var/log/journal
+    size: 256M
+    fs_type: ext4
+    fs_opts: -L JOURNALD
+    mount_opts:
+      - nosuid
+  - name: pacman
+    group: storage
+    path: /var/cache/pacman
+    size: 2G
+    fs_type: ext4
+    fs_opts: -L PACMAN
+    mount_opts:
+      - nosuid
+      - nodev
+      - noexec
+  - name: home
+    group: storage
+    path: /home
+    size: 256M
+    fs_type: ext4
+    fs_opts: -L HOME
+    mount_opts:
+      - nosuid
+      - nodev
+
+tailscale_auth_key: !vault |
+  $ANSIBLE_VAULT;1.1;AES256
+  39656162316236393633623065666538363538623765326464383861366631333936346634636132
+  3032303330326665653563386432353561363461626439620a323137343934363331346665623636
+  39623232663064663961393333303565366231336130656661643230393563383937363030356361
+  3266643633356366310a633732653263663866376135666463316563333738666238353931643734
+  61363630313332393939626333386630303661653434656639303431356231323763303038343432
+  35313236383435333038633931326562613035633531613664383561323332616236633862623831
+  373237376663653135333534646166333962

--- a/plays/test.yaml
+++ b/plays/test.yaml
@@ -1,0 +1,13 @@
+---
+- name: Configure test servers
+  hosts: test
+  become: true
+  become_user: root
+
+  roles:
+    - role: ufw
+      tags:
+        - ufw
+    - role: tailscale
+      tags:
+        - tailscale

--- a/roles/bootstrap/files/mirrorlist
+++ b/roles/bootstrap/files/mirrorlist
@@ -1,5 +1,5 @@
 #  DO NOT EDIT - Managed by Ansible
 
+Server = https://repo.c48.uk/arch/$repo/os/$arch
 Server = https://mirrors.ukfast.co.uk/sites/archlinux.org/$repo/os/$arch
-Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch
 Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch

--- a/roles/issue/templates/issue.jinja
+++ b/roles/issue/templates/issue.jinja
@@ -44,9 +44,12 @@
 {%- if ansible_facts.distribution != "Archlinux" %} ({{ ansible_facts.distribution_version }}){% endif %}
 
   \e{halfbright}          Kernel\e{reset}: \r
-
+{%  if ansible_facts.default_ipv6.address is defined %}
   \e{halfbright}    IPv6 Address\e{reset}: {{ ansible_facts.default_ipv6.address | split('/') | first }}
+{%  endif %}
+{%  if ansible_facts.default_ipv4.address is defined %}
   \e{halfbright}    IPv4 Address\e{reset}: {{ ansible_facts.default_ipv4.address | split('/') | first }}
+{%  endif %}
 
 \e{halfbright}──> \e{reset}Login
 {{ '\n' }}

--- a/roles/postgresql/tasks/pre-flight.yaml
+++ b/roles/postgresql/tasks/pre-flight.yaml
@@ -29,15 +29,11 @@
       is enabled.
   when: >-
     postgresql_walg_enabled and
-    (
-      postgresql_walg_aws_region is not defined or
-      postgresql_walg_aws_region == "" or
-      postgresql_walg_aws_access_key_id is not defined or
-      postgresql_walg_aws_access_key_id == "" or
-      postgresql_walg_aws_secret_access_key is not defined or
-      postgresql_walg_aws_secret_access_key == "" or
-      postgresql_walg_aws_s3_prefix is not defined or
-      postgresql_walg_aws_s3_prefix == ""
+    not (
+      postgresql_walg_aws_region and
+      postgresql_walg_aws_access_key_id and
+      postgresql_walg_aws_secret_access_key and
+      postgresql_walg_aws_s3_prefix
     )
   tags:
     - postgresql

--- a/roles/systemd_networkd/templates/ethernet.network.jinja
+++ b/roles/systemd_networkd/templates/ethernet.network.jinja
@@ -1,23 +1,36 @@
 # {{ ansible_managed }}
 
 [Match]
+{% if ansible_facts.default_ipv4.interface is defined %}
 MACAddress={{ ansible_facts.default_ipv4.macaddress }}
+{% elif ansible_facts.default_ipv6.interface is defined %}
+MACAddress={{ ansible_facts.default_ipv6.macaddress }}
+{% endif %}
 
 [Link]
+{% if ansible_facts.default_ipv4.interface is defined %}
 MTUBytes={{ ansible_facts.default_ipv4.mtu }}
+{% elif ansible_facts.default_ipv6.interface is defined %}
+MTUBytes={{ ansible_facts.default_ipv6.mtu }}
+{% endif %}
 
 [Network]
 DHCP=no
 LLMNR=no
 MulticastDNS=no
 IPForward=no
+{%- if ansible_facts.default_ipv6.interface is defined %}
 IPv6PrivacyExtensions=no
+{%- endif %}
+{%- if ansible_facts.default_ipv4.interface is defined %}
 
 [Address]
 Address={{ ansible_facts.default_ipv4.address }}/{{ ansible_facts.default_ipv4.prefix }}
 
 [Route]
 Gateway={{ ansible_facts.default_ipv4.gateway }}
+{%- endif %}
+{%- if ansible_facts.default_ipv6.interface is defined %}
 
 [Address]
 Address={{ ansible_facts.default_ipv6.address }}/{{ ansible_facts.default_ipv6.prefix }}
@@ -25,3 +38,4 @@ Address={{ ansible_facts.default_ipv6.address }}/{{ ansible_facts.default_ipv6.p
 [Route]
 Gateway={{ ansible_facts.default_ipv6.gateway }}
 GatewayOnLink=yes
+{%- endif %}

--- a/roles/systemd_networkd/templates/hosts.jinja
+++ b/roles/systemd_networkd/templates/hosts.jinja
@@ -4,8 +4,12 @@
 ::1 localhost
 
 # Local host addresses
+{%  if ansible_facts.default_ipv4.address is defined %}
 {{ ansible_facts.default_ipv4.address }} {{ ansible_facts.fqdn }} {{ ansible_facts.hostname }}
+{%  endif %}
+{%  if ansible_facts.default_ipv6.address is defined %}
 {{ ansible_facts.default_ipv6.address }} {{ ansible_facts.fqdn }} {{ ansible_facts.hostname }}
+{% endif %}
 {%  if systemd_networkd_hosts_entries | length > 0 %}
 
 # Additional host addresses

--- a/roles/ufw/tasks/rules.yaml
+++ b/roles/ufw/tasks/rules.yaml
@@ -9,6 +9,14 @@
     proto: "{{ rule.proto | default(omit) }}"
     port: "{{ rule.port | default(omit) }}"
     comment: "{{ rule.comment | default(omit) }}"
+  when: >-
+    ( rule.from_ip is not defined and rule.to_ip is not defined ) or
+    ( ( ( rule.from_ip is defined and rule.from_ip is ansible.utils.ipv4 ) or
+        ( rule.to_ip is defined and rule.to_ip is ansible.utils.ipv4 ) )
+          and ansible_facts.default_ipv4.address is defined ) or
+    ( ( ( rule.from_ip is defined and rule.from_ip is ansible.utils.ipv6 ) or
+        ( rule.to_ip is defined and rule.to_ip is ansible.utils.ipv6 ) )
+          and ansible_facts.default_ipv6.address is defined )
   loop: "{{ ufw_default_rules }}"
   loop_control:
     label: >-
@@ -27,6 +35,14 @@
     port: "{{ rule.port | default(omit) }}"
     comment: "{{ rule.comment | default(omit) }}"
     state: '{{ "enabled" if rule.enabled | default(true) else "disabled" }}'
+  when: >-
+    ( rule.from_ip is not defined and rule.to_ip is not defined ) or
+    ( ( ( rule.from_ip is defined and rule.from_ip is ansible.utils.ipv4 ) or
+        ( rule.from_ip is defined and rule.from_ip is ansible.utils.ipv4 ) )
+          and ansible_facts.default_ipv4.address is defined ) or
+    ( ( ( rule.from_ip is defined and rule.from_ip is ansible.utils.ipv6 ) or
+        ( rule.from_ip is defined and rule.from_ip is ansible.utils.ipv6 ) )
+          and ansible_facts.default_ipv6.address is defined )
   loop: "{{ ufw_extra_rules }}"
   loop_control:
     label: >-


### PR DESCRIPTION
Update multiple roles to enable IPv6-only installations (through the `bootstrap` and `baseline` plays), ensuring both IPv4 and IPv6 usage are optional. 

## Checklist

Before raising this Pull Request, please review the `CONTRIBUTING.md` document for guidance on how best to work with this repository and its code. Additionally, please review and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests to check
- [ ] I have run and added tests to prove my changes are effective and correctly
- [ ] I have made corresponding changes to the documentation as needed
- [x] Each commit in, and this PR, have a meaningful subject and body for context
- [x] I have added `release/...` and `{update,type}/...` labels to this PR
