### PR TITLE
feat: Add DNS64 support for Bind

### DIFF
--- a/plays/dns.yaml
+++ b/plays/dns.yaml
@@ -3,6 +3,18 @@
   hosts: dns
   become: true
   become_user: root
+
+  # Each DNS node must know about the configuration of the other DNS nodes, in
+  # order to correctly configure the BIND server for replication and permit the
+  # necessary firewall rules
+  pre_tasks:
+    - name: Gather facts from all DNS hosts
+      ansible.builtin.setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      when: hostvars[item].ansible.ansible_hostname is not defined
+      with_items: "{{ groups['dns'] }}"
+
   roles:
     - role: ufw
       tags:

--- a/plays/group_vars/dns.yaml
+++ b/plays/group_vars/dns.yaml
@@ -110,6 +110,19 @@ bind_rndc_group_members:
 bind_tsig_group_members:
   - user: jonathan
 
+bind_dns64_hosts:
+  - address: 2a02:8010:8006:3a36::/64
+    comment: >-
+      n3tuk Network for Development Proxmox Cluster Nodes
+  - address: 2a02:8010:8006:3a37::/64
+    comment: >-
+      n3tuk Networks for Talos Nodes in the Development Kubernetes Cluster
+  - address: 2a02:8010:8006:3a38::/64
+  - address: 2a02:8010:8006:3a42::/64
+  - address: fd7a:115c:a1e0::4834:c565
+    comment: >-
+      cynon.bridgend.n3t.uk (cynon) Tailscale Node
+
 bind_views:
   - name: tailnet
     comment: |-

--- a/roles/bind/defaults/main.yaml
+++ b/roles/bind/defaults/main.yaml
@@ -7,6 +7,8 @@ bind_listen_ipv6_addresses:
   - any
 bind_port_dns: 53
 
+bind_dns64_hosts: []
+
 bind_forwarders: []
 
 bind_views: []

--- a/roles/bind/templates/named.conf.jinja
+++ b/roles/bind/templates/named.conf.jinja
@@ -9,6 +9,14 @@ options {
 
   notify explicit;
   allow-transfer { none; };
+{%  if bind_dns64_hosts | length > 0 %}
+
+  dns64 64:ff9b::/96 {
+    clients { dns64-hosts-acl; };
+    mapped { any; };
+    break-dnssec yes;
+  };
+{%  endif %}
 
   forward only;
   forwarders {
@@ -19,6 +27,17 @@ options {
 
   dnssec-validation {{ bind_dnssec_validation }};
 };
+{%  if bind_dns64_hosts | length > 0 %}
+
+acl dns64-hosts-acl {
+{%    for host in bind_dns64_hosts %}
+{%      if host.comment is defined %}
+  // {{ host.comment }}
+{%      endif %}
+  {{ host.address }};
+{%    endfor %}
+};
+{%  endif %}
 {%  if bind_rndc_key_secret | length > 0 %}
 
 // Set up the RNDC key for remote administration, but only from within the


### PR DESCRIPTION
Add support for resolving DNS64 queries for selected hosts within the network, enabling NAT64 operations on configured IPv6-only networks.

## Checklist

Before raising this Pull Request, please review the `CONTRIBUTING.md` document for guidance on how best to work with this repository and its code. Additionally, please review and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests to check
- [ ] I have run and added tests to prove my changes are effective and correctly
- [ ] I have made corresponding changes to the documentation as needed
- [x] Each commit in, and this PR, have a meaningful subject and body for context
- [x] I have added `release/...` and `{update,type}/...` labels to this PR
