### PR TITLE
feat: Enable support for Tailscale Peer Relays

### DIFF
--- a/plays/group_vars/external.yaml
+++ b/plays/group_vars/external.yaml
@@ -111,6 +111,8 @@ ufw_default_rules:
     port: 22
     comment: Allow SSH from anywhere
 
+tailscale_exit_node: true
+tailscale_peer_relay: true
 tailscale_auth_key: !vault |
   $ANSIBLE_VAULT;1.1;AES256
   39353861626532386266626139663164313461336330663538393136353233663133376534373637

--- a/roles/tailscale/README.md
+++ b/roles/tailscale/README.md
@@ -11,15 +11,18 @@ None other than the Ansible Role.
 
 ## Role Variables
 
-| Variable                  | Default | Description                                                                                                                                  |
-| :------------------------ | :------ | :------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tailscale_auth_key`      | `""`    | (**required**) The Authorisation Key created in the Tailscale Admin Console to allow this client to join the Tailscale network.              |
-| `tailscale_args`          | `""`    | (**optional**) Additional command-line arguments to add to the Tailscale CLI when joining the Tailscale network.                             |
-| `tailscale_up_timeout`    | `120`   | (**optional**) The number of seconds to wait for Tailscale to connect to the network after running `tailscale up`.                           |
-| `tailscale_exit_node`     | `false` | (**optional**) Whether to configure this Tailscale client as an exit node for the Tailscale network.                                         |
-| `tailscale_accept_routes` | `true`  | (**optional**) Whether to accept routes advertised by other Tailscale nodes on the network.                                                  |
-| `tailscale_hostname`      | `""`    | (**optional**) If set, override the hostname that this Tailscale client uses on the Tailscale network from the one configured on the system. |
-| `tailscale_ssh`           | `false` | (**optional**) Whether to enable Tailscale SSH on this client.                                                                               |
+| Variable                    | Default | Description                                                                                                                                  |
+| :-------------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tailscale_auth_key`        | `""`    | (**required**) The Authorisation Key created in the Tailscale Admin Console to allow this client to join the Tailscale network.              |
+| `tailscale_args`            | `""`    | (**optional**) Additional command-line arguments to add to the Tailscale CLI when joining the Tailscale network.                             |
+| `tailscale_up_timeout`      | `120`   | (**optional**) The number of seconds to wait for Tailscale to connect to the network after running `tailscale up`.                           |
+| `tailscale_port`            | `41641` | (**optional**) The port to use for Tailscale VPN client access on this server.                                                               |
+| `tailscale_exit_node`       | `false` | (**optional**) Whether to configure this Tailscale client as an exit node for the Tailscale network.                                         |
+| `tailscale_accept_routes`   | `true`  | (**optional**) Whether to accept routes advertised by other Tailscale nodes on the network.                                                  |
+| `tailscale_hostname`        | `""`    | (**optional**) If set, override the hostname that this Tailscale client uses on the Tailscale network from the one configured on the system. |
+| `tailscale_ssh`             | `true`  | (**optional**) Whether to enable Tailscale SSH on this device.                                                                               |
+| `tailscale_peer_relay`      | `false` | (**optional**) Whether to enable Tailscale Peer Relay on this server.                                                                        |
+| `tailscale_peer_relay_port` | `41642` | (**optional**) The port to use for Tailscale Peer Relay access on this server.                                                               |
 
 ## Dependencies
 

--- a/roles/tailscale/defaults/main.yaml
+++ b/roles/tailscale/defaults/main.yaml
@@ -5,7 +5,11 @@ tailscale_auth_key: ""
 tailscale_args: ""
 tailscale_up_timeout: 120
 
+tailscale_port: 41641
 tailscale_exit_node: false
 tailscale_accept_routes: true
 tailscale_hostname: ""
-tailscale_ssh: false
+tailscale_ssh: true
+
+tailscale_peer_relay: false
+tailscale_peer_relay_port: 41642

--- a/roles/tailscale/files/10-ip-forwarding.conf
+++ b/roles/tailscale/files/10-ip-forwarding.conf
@@ -1,0 +1,4 @@
+# DO NOT EDIT - Managed by Ansible
+
+net.ipv6.conf.all.forwarding = 1
+net.ipv4.ip_forward = 1

--- a/roles/tailscale/tasks/firewall.yaml
+++ b/roles/tailscale/tasks/firewall.yaml
@@ -1,0 +1,40 @@
+---
+# firewall-specific tasks file for tailscale
+
+- name: Enable firewall access for Tailscale Clients
+  community.general.ufw:
+    rule: allow
+    proto: udp
+    port: "{{ tailscale_port }}"
+    comment: Allow Tailscale Client Access
+  tags:
+    - tailscale
+    - firewall
+
+- name: Enable firewall access for Tailscale Peer Relays
+  community.general.ufw:
+    rule: allow
+    proto: udp
+    port: "{{ tailscale_peer_relay_port }}"
+    comment: Allow Tailscale Peer Relay Access
+  when: tailscale_peer_relay
+  tags:
+    - tailscale
+    - firewall
+
+- name: Install sysctl settings for Tailscale Exit Nodes
+  ansible.builtin.copy:
+    src: "{{ config }}"
+    dest: /etc/sysctl.d/{{ config }}
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
+  loop:
+    - 10-ip-forwarding.conf
+  loop_control:
+    label: /etc/sysctl.d/{{ config }}
+    loop_var: config
+  when: tailscale_exit_node
+  tags:
+    - networking
+    - configuration

--- a/roles/tailscale/tasks/main.yaml
+++ b/roles/tailscale/tasks/main.yaml
@@ -15,6 +15,10 @@
     file: debian.yaml
   when: ansible_facts.distribution == 'Debian'
 
+- name: Set up the Tailscale firewall rules
+  ansible.builtin.include_tasks:
+    file: firewall.yaml
+
 - name: Set up Tailscale
   ansible.builtin.include_tasks:
     file: setup.yaml

--- a/roles/tailscale/tasks/setup.yaml
+++ b/roles/tailscale/tasks/setup.yaml
@@ -43,8 +43,11 @@
     {% if tailscale_hostname is defined and tailscale_hostname | length > 0 %}
       --hostname={{ tailscale_hostname | trim }}
     {% endif %}
-    {% if tailscale_exit_node %}
+    {% if tailscale_peer_relay %}
       --exit-node=true
+    {% endif %}
+    {% if tailscale_exit_node %}
+      --advertise-exit-node=true
     {% endif %}
     {% if tailscale_accept_routes %}
       --accept-routes=true
@@ -82,6 +85,18 @@
     (not ansible_check_mode) and
     (tailscale_start is failed) and
     (tailscale_start.stdout | length > 0)
+  tags:
+    - tailscale
+    - setup
+
+- name: Bring up Tailscale Relay Node
+  ansible.builtin.command: >-
+    tailscale set
+      --relay-server-port {{ tailscale_peer_relay_port }}
+  changed_when: true
+  when: >-
+    (not ansible_check_mode) and
+    tailscale_peer_relay
   tags:
     - tailscale
     - setup


### PR DESCRIPTION
Enable support for configuring a new node as a Tailscale Peer Relay, allowing it to route traffic when direct connections cannot be established. Especially useful for IPv4 NAT'ing and IPv6-only network access from IPv4-only clients.

## Checklist

Before raising this Pull Request, please review the `CONTRIBUTING.md` document for guidance on how best to work with this repository and its code. Additionally, please review and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests to check
- [ ] I have run and added tests to prove my changes are effective and correctly
- [ ] I have made corresponding changes to the documentation as needed
- [x] Each commit in, and this PR, have a meaningful subject and body for context
- [x] I have added `release/...` and `{update,type}/...` labels to this PR
