### PR TITLE
Feat: Add DNS-over-TLS and DNS-over-HTTP to BIND

### DIFF
--- a/plays/bind.yaml
+++ b/plays/bind.yaml
@@ -12,13 +12,17 @@
       ansible.builtin.setup:
       delegate_to: "{{ item }}"
       delegate_facts: true
-      when: hostvars[item].ansible.ansible_hostname is not defined
+      when: >-
+        hostvars[item].ansible.default_ipv4 is not defined and
+        hostvars[item].ansible.default_ipv6 is not defined
       with_items: "{{ groups['ca'] }}"
     - name: Gather facts from all BIND hosts
       ansible.builtin.setup:
       delegate_to: "{{ item }}"
       delegate_facts: true
-      when: hostvars[item].ansible.ansible_hostname is not defined
+      when: >-
+        hostvars[item].ansible.default_ipv4 is not defined and
+        hostvars[item].ansible.default_ipv6 is not defined
       with_items: "{{ groups['bind'] }}"
 
   roles:

--- a/plays/bind.yaml
+++ b/plays/bind.yaml
@@ -8,6 +8,12 @@
   # order to correctly configure the BIND server for replication and permit the
   # necessary traffic via the firewall rules
   pre_tasks:
+    - name: Gather facts from all CA hosts
+      ansible.builtin.setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      when: hostvars[item].ansible.ansible_hostname is not defined
+      with_items: "{{ groups['ca'] }}"
     - name: Gather facts from all BIND hosts
       ansible.builtin.setup:
       delegate_to: "{{ item }}"
@@ -16,6 +22,9 @@
       with_items: "{{ groups['bind'] }}"
 
   roles:
+    - role: lego
+      tags:
+        - lego
     - role: bind
       tags:
         - bind

--- a/plays/dns.yaml
+++ b/plays/dns.yaml
@@ -4,24 +4,18 @@
   become: true
   become_user: root
 
-  # Each BIND node must know about the configuration of the other BIND nodes in
-  # order to correctly configure the BIND server for replication and permit the
-  # necessary traffic via the firewall rules
-  pre_tasks:
-    - name: Gather facts from all BIND hosts
-      ansible.builtin.setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: true
-      when: hostvars[item].ansible.ansible_hostname is not defined
-      with_items: "{{ groups['bind'] }}"
-
   roles:
     - role: ufw
       tags:
         - ufw
-    - role: bind
-      tags:
-        - bind
     - role: tailscale
       tags:
         - tailscale
+
+# Include a dedicated play for installing and managing the BIND service, as it
+# needs to some steps to configure the BIND service and firewall rules that are
+# specific to the BIND service
+# - include_play: plays/bind.yaml
+#   when: "'bind' in group_names"
+#   tags:
+#     - bind

--- a/plays/dns.yaml
+++ b/plays/dns.yaml
@@ -15,7 +15,8 @@
 # Include a dedicated play for installing and managing the BIND service, as it
 # needs to some steps to configure the BIND service and firewall rules that are
 # specific to the BIND service
-# - include_play: plays/bind.yaml
-#   when: "'bind' in group_names"
-#   tags:
-#     - bind
+- name: Configure Bind Services
+  import_playbook: bind.yaml
+  when: "'bind' in group_names"
+  tags:
+    - bind

--- a/plays/external.yaml
+++ b/plays/external.yaml
@@ -4,24 +4,18 @@
   become: true
   become_user: root
 
-  # Each BIND node must know about the configuration of the other BIND nodes in
-  # order to correctly configure the BIND server for replication and permit the
-  # necessary traffic via the firewall rules
-  pre_tasks:
-    - name: Gather facts from all BIND hosts
-      ansible.builtin.setup:
-      delegate_to: "{{ item }}"
-      delegate_facts: true
-      when: hostvars[item].ansible.ansible_hostname is not defined
-      with_items: "{{ groups['bind'] }}"
-
   roles:
     - role: ufw
       tags:
         - ufw
-    - role: bind
-      tags:
-        - bind
     - role: tailscale
       tags:
         - tailscale
+
+# Include a dedicated play for installing and managing the BIND service, as it
+# needs to some steps to configure the BIND service and firewall rules that are
+# specific to the BIND service
+# - include_play: plays/bind.yaml
+#   when: "'bind' in group_names"
+#   tags:
+#     - bind

--- a/plays/external.yaml
+++ b/plays/external.yaml
@@ -15,7 +15,8 @@
 # Include a dedicated play for installing and managing the BIND service, as it
 # needs to some steps to configure the BIND service and firewall rules that are
 # specific to the BIND service
-# - include_play: plays/bind.yaml
-#   when: "'bind' in group_names"
-#   tags:
-#     - bind
+- name: Configure Bind Services
+  import_playbook: bind.yaml
+  when: "'bind' in group_names"
+  tags:
+    - bind

--- a/plays/group_vars/bind.yaml
+++ b/plays/group_vars/bind.yaml
@@ -1,13 +1,32 @@
 ---
-bind_forwarders:
-  - 2606:4700:4700::1111
-  - 2606:4700:4700::1001
-bind_dnssec_validation: "no"
-
 bind_rndc_group_members:
   - user: jonathan
 bind_tsig_group_members:
   - user: jonathan
+
+bind_forwarders:
+  - 2606:4700:4700::1111
+  - 2606:4700:4700::1001
+bind_forwarders_dot_enable: true
+bind_forwarders_dot_name: one.one.one.one
+bind_forwarders_dot_port: 853
+bind_forwarders_dot_ca_cert: |-
+  -----BEGIN CERTIFICATE-----
+  MIICjTCCAhSgAwIBAgIIdebfy8FoW6gwCgYIKoZIzj0EAwIwfDELMAkGA1UEBhMC
+  VVMxDjAMBgNVBAgMBVRleGFzMRAwDgYDVQQHDAdIb3VzdG9uMRgwFgYDVQQKDA9T
+  U0wgQ29ycG9yYXRpb24xMTAvBgNVBAMMKFNTTC5jb20gUm9vdCBDZXJ0aWZpY2F0
+  aW9uIEF1dGhvcml0eSBFQ0MwHhcNMTYwMjEyMTgxNDAzWhcNNDEwMjEyMTgxNDAz
+  WjB8MQswCQYDVQQGEwJVUzEOMAwGA1UECAwFVGV4YXMxEDAOBgNVBAcMB0hvdXN0
+  b24xGDAWBgNVBAoMD1NTTCBDb3Jwb3JhdGlvbjExMC8GA1UEAwwoU1NMLmNvbSBS
+  b290IENlcnRpZmljYXRpb24gQXV0aG9yaXR5IEVDQzB2MBAGByqGSM49AgEGBSuB
+  BAAiA2IABEVuqVDEpiM2nl8ojRfLliJkP9x6jh3MCLOicSS6jkm5BBtHllirLZXI
+  7Z4INcgn64mMU1jrYor+8FsPazFSY0E7ic3s7LaNGdM0B9y7xgZ/wkWV7Mt/qCPg
+  CemB+vNH06NjMGEwHQYDVR0OBBYEFILRhXMw5zUE044CkvvlpNHEIejNMA8GA1Ud
+  EwEB/wQFMAMBAf8wHwYDVR0jBBgwFoAUgtGFczDnNQTTjgKS++Wk0cQh6M0wDgYD
+  VR0PAQH/BAQDAgGGMAoGCCqGSM49BAMCA2cAMGQCMG/n61kRpGDPYbCWe+0F+S8T
+  kdzt5fxQaxFGRrMcIQBiu77D5+jNB5n5DQtdcj7EqgIwH7y6C+IwJPt8bYBVCpk+
+  gA0z5Wajs6O7pdWLjwkspl1+4vAHCGht0nxpbl/f5Wpl
+  -----END CERTIFICATE-----
 
 bind_dns64_hosts:
   - comment: >-

--- a/plays/group_vars/ca.yaml
+++ b/plays/group_vars/ca.yaml
@@ -154,6 +154,8 @@ stepca_x509_allow_dns:
   - "*.n3t.uk"
   - "ca.n3t.uk"
   - "*.ca.n3t.uk"
+  - "*.london.n3t.uk"
+  - "*.amsterdam.n3t.uk"
   - "*.services.n3t.uk"
   - "*.development.n3t.uk"
   - "*.production.n3t.uk"
@@ -169,6 +171,10 @@ stepca_x509_allow_ip:
   # Localhost addresses for local services
   - "::1"
   - "127.0.0.1/32"
+  # Mythic Beasts VPSes
+  - 2a00:1098:5bf::/64
+  - 176.126.245.211/32
+  - 176.126.245.212/32
   # Internal/external addresses for services in n3t.uk and kub3.uk
   - "2a02:8010:8006::/48"
   - "172.23.0.0/16"

--- a/plays/group_vars/dns.yaml
+++ b/plays/group_vars/dns.yaml
@@ -119,3 +119,8 @@ bind_recursive_hosts:
       external-02.amsterdam.n3t.uk Server
     address: 2a00:1098:5bf::2/128
   - address: 176.126.245.212
+
+lego_acme_email: admin@n3t.uk
+lego_acme_server: https://ca.n3t.uk/acme/n3tuk/directory
+lego_acme_servers_group: ca
+lego_acme_mode: port

--- a/plays/group_vars/dns.yaml
+++ b/plays/group_vars/dns.yaml
@@ -123,4 +123,4 @@ bind_recursive_hosts:
 lego_acme_email: admin@n3t.uk
 lego_acme_server: https://ca.n3t.uk/acme/n3tuk/directory
 lego_acme_servers_group: ca
-lego_acme_mode: port
+lego_acme_mode: standalone

--- a/plays/group_vars/external.yaml
+++ b/plays/group_vars/external.yaml
@@ -137,3 +137,8 @@ bind_recursive_hosts:
   - comment: >-
       external-02.amsterdam.n3t.uk Server
     address: 2a00:1098:5bf::2/128
+
+lego_acme_email: admin@n3t.uk
+lego_acme_server: https://ca.n3t.uk/acme/n3tuk/directory
+lego_acme_servers_group: ca
+lego_acme_mode: port

--- a/plays/group_vars/external.yaml
+++ b/plays/group_vars/external.yaml
@@ -138,7 +138,13 @@ bind_recursive_hosts:
       external-02.amsterdam.n3t.uk Server
     address: 2a00:1098:5bf::2/128
 
+lego_firewall_ipv4_replace:
+  "172.23.41.4": "82.69.106.64"
+  # We'll skip this address as the above address will effectively install the
+  # external IP address for both of the CA servers by the one rule
+  "172.23.41.5": skipped
+
 lego_acme_email: admin@n3t.uk
 lego_acme_server: https://ca.n3t.uk/acme/n3tuk/directory
 lego_acme_servers_group: ca
-lego_acme_mode: port
+lego_acme_mode: standalone

--- a/roles/bind/README.md
+++ b/roles/bind/README.md
@@ -40,17 +40,24 @@ None other than the Ansible Role.
 
 ## Role Variables
 
-| Variable                     | Default   | Description                                                                                                                               |
-| :--------------------------- | :-------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
-| `bind_listen_ipv4_addresses` | `["any"]` | (**optional**) A list of IPv4 addresses for `bind` to listen on, on the ports selected.                                                   |
-| `bind_listen_ipv6_addresses` | `["any"]` | (**optional**) A list of IPv6 addresses for `bind` to listen on, on the ports selected .                                                  |
-| `bind_port_dns`              | `53`      | (**optional**) The port for `bind` to listen on for standard, unencrypted, DNS requests.                                                  |
-| `bind_forwarders`            | `[]`      | (**optional**) A list of IP addresses of upstream DNS servers for `bind` to forward requests to when it cannot resolve them itself.       |
-| `bind_views`                 | `[]`      | (**optional**) A list of dictionaries containing the structure of the views and zones to create in `bind`. See below for an example.      |
-| `bind_dnssec_validation`     | `true`    | (**optional**) Whether to enable DNSSEC validation in `bind` when forwarding and resolving DNS requests upstream from downstream clients. |
-| `bind_rndc_key_secret`       | `""`      | (**optional**) The secret key to use for the `rndc` control channel.                                                                      |
-| `bind_rndc_group_members`    | `[]`      | (**optional**) A list of users that should have access to the `rndc` control channel configuration file, and hence can use `rndc`.        |
-| `bind_tsig_group_members`    | `[]`      | (**optional**) A list of users that should have access to the TSIG keys and hence can use `nsupdate` on the master servers.               |
+| Variable                      | Default   | Description                                                                                                                                                 |
+| :---------------------------- | :-------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bind_listen_ipv4_addresses`  | `["any"]` | (**optional**) A list of IPv4 addresses for `bind` to listen on, on the ports selected.                                                                     |
+| `bind_listen_ipv6_addresses`  | `["any"]` | (**optional**) A list of IPv6 addresses for `bind` to listen on, on the ports selected .                                                                    |
+| `bind_dot_enable`             | `false`   | (**optional**) Whether to enable DNS-over-TLS (DoT) support in `bind`.                                                                                      |
+| `bind_doh_enable`             | `false`   | (**optional**) Whether to enable DNS-over-HTTPS (DoH) support in `bind`.                                                                                    |
+| `bind_port_dns`               | `53`      | (**optional**) The port for `bind` to listen on for standard, unencrypted, DNS requests.                                                                    |
+| `bind_port_dot`               | `853`     | (**optional**) The port for `bind` to listen on for DNS-over-TLS (DoT) requests.                                                                            |
+| `bind_port_doh`               | `443`     | (**optional**) The port for `bind` to listen on for DNS-over-HTTPS (DoH) requests (a firewall port will only be opened for this port if port `443` is used. |
+| `bind_forwarders`             | `[]`      | (**optional**) A list of IP addresses of upstream DNS servers for `bind` to forward requests to when it cannot resolve them itself.                         |
+| `bind_forwarders_dot_enable`  | `false`   | (**optional**) Whether to enable DNS-over-TLS (DoT) support when forwarding requests to upstream DNS servers.                                               |
+| `bind_forwarders_dot_name`    | `""`      | (**optional**) The hostname of the upstream DNS server to use for DNS-over-TLS (DoT) forwarding.                                                            |
+| `bind_forwarders_dot_ca_cert` | `""`      | (**optional**) The CA root certificate to use for DNS-over-TLS (DoT) forwarding.                                                                            |
+| `bind_views`                  | `[]`      | (**optional**) A list of dictionaries containing the structure of the views and zones to create in `bind`. See below for an example.                        |
+| `bind_dnssec_validation`      | `true`    | (**optional**) Whether to enable DNSSEC validation in `bind` when forwarding and resolving DNS requests upstream from downstream clients.                   |
+| `bind_rndc_key_secret`        | `""`      | (**optional**) The secret key to use for the `rndc` control channel.                                                                                        |
+| `bind_rndc_group_members`     | `[]`      | (**optional**) A list of users that should have access to the `rndc` control channel configuration file, and hence can use `rndc`.                          |
+| `bind_tsig_group_members`     | `[]`      | (**optional**) A list of users that should have access to the TSIG keys and hence can use `nsupdate` on the master servers.                                 |
 
 ## Dependencies
 

--- a/roles/bind/defaults/main.yaml
+++ b/roles/bind/defaults/main.yaml
@@ -5,12 +5,22 @@ bind_listen_ipv4_addresses:
   - any
 bind_listen_ipv6_addresses:
   - any
-bind_port_dns: 53
+bind_port: 53
+
+bind_dot_enable: true
+bind_dot_port: 853
+
+bind_doh_enable: true
+bind_doh_port: 443
 
 bind_dns64_hosts: []
 bind_recursive_hosts: []
 
 bind_forwarders: []
+bind_forwarders_dot_enable: false
+bind_forwarders_dot_name:
+bind_forwarders_dot_port: 853
+bind_forwarders_dot_ca_cert:
 
 bind_views: []
 # - name: example
@@ -24,12 +34,13 @@ bind_views: []
 #       forwarders:
 #         - 1.1.1.1
 #   cidrs:
-#     - 192.0.2.0/24
-#     - 198.51.100.0/24
-#     - 203.0.113.0/24
-#     - 2001:db8:1::/48
-#     - 2001:db8:2::/48
-#     - 2001:db8:3::/48
+#     - comment: comment
+#       address; 192.0.2.0/24
+#     - address: 198.51.100.0/24
+#     - address: 203.0.113.0/24
+#     - address 2001:db8:1::/48
+#     - address 2001:db8:2::/48
+#     - address 2001:db8:3::/48
 #   servers:
 #     master: dns-01.example.com
 #     slaves:
@@ -45,7 +56,7 @@ bind_views: []
 #         grants:
 #           - zonesub A AAAA CNAME TXT
 #         cidrs:
-#            - 10.0.0.0/8
+#            - address: 10.0.0.0/8
 #         secret: ...
 
 bind_dnssec_validation: auto

--- a/roles/bind/handlers/main.yaml
+++ b/roles/bind/handlers/main.yaml
@@ -7,3 +7,11 @@
     state: reloaded
   when: >-
     not ansible_check_mode
+
+- name: Trigger Lego for BIND certificate renewal
+  ansible.builtin.systemd:
+    name: "lego@{{ bind_service_name }}.service"
+    state: started
+  when: >-
+    ( bind_doh_enable or bind_dot_enable ) and
+    not ansible_check_mode

--- a/roles/bind/tasks/configure.yaml
+++ b/roles/bind/tasks/configure.yaml
@@ -10,6 +10,7 @@
     mode: u=rwx,g=rx,o=
   loop:
     - "{{ bind_var_path }}"
+    - "{{ bind_var_path }}/certs"
     - "{{ bind_log_path }}"
   loop_control:
     label: "{{ directory }}"
@@ -145,4 +146,50 @@
     loop_var: view
   tags:
     - bind
+    - configuration
+
+- name: Create directory for Lego certificates
+  ansible.builtin.file:
+    path: "{{ lego_lib_path }}/{{ bind_service_name }}"
+    state: directory
+    owner: root
+    group: root
+    mode: u=rwx,g=,o=
+  when: >-
+    bind_doh_enable or bind_dot_enable
+  tags:
+    - bind
+    - lego
+    - configuration
+
+- name: Create or update the Lego configuration file
+  ansible.builtin.template:
+    src: lego.conf.jinja
+    dest: "{{ lego_etc_path }}/{{ bind_service_name }}.conf"
+    owner: root
+    group: root
+    mode: u=rw,g=,o=
+  when: >-
+    bind_doh_enable or bind_dot_enable
+  notify:
+    - Trigger Lego for BIND certificate renewal
+  tags:
+    - bind
+    - lego
+    - configuration
+
+- name: Create or update the Lego post-run hook
+  ansible.builtin.template:
+    src: lego.sh.jinja
+    dest: "{{ lego_usr_path }}/{{ bind_service_name }}"
+    owner: root
+    group: root
+    mode: u=rwx,g=,o=
+  when: >-
+    bind_doh_enable or bind_dot_enable
+  notify:
+    - Trigger Lego for BIND certificate renewal
+  tags:
+    - bind
+    - lego
     - configuration

--- a/roles/bind/tasks/configure.yaml
+++ b/roles/bind/tasks/configure.yaml
@@ -34,10 +34,25 @@
     - bind
     - configuration
 
+- name: Create or update the forwarders CA root certificate
+  ansible.builtin.copy:
+    content: "{{ bind_forwarders_dot_ca_cert }}"
+    dest: "{{ bind_var_path }}/certs/ca.pem"
+    owner: "{{ bind_service_user }}"
+    group: "{{ bind_service_group }}"
+    mode: u=rw,g=r,o=
+  when: >-
+    bind_forwarders_dot_enable and
+    bind_forwarders_dot_ca_cert is defined
+  notify:
+    - Reload BIND
+  tags:
+    - bind
+    - configuration
+
 - name: Create or update the named.conf configuration file
   ansible.builtin.template:
     src: named.conf.jinja
-    # yamllint disable-line rule:line-length
     dest: "{{ bind_etc_path }}/{{ bind_etc_name }}"
     owner: "{{ bind_service_user }}"
     group: "{{ bind_service_group }}"

--- a/roles/bind/tasks/firewall.yaml
+++ b/roles/bind/tasks/firewall.yaml
@@ -4,15 +4,29 @@
 - name: Enable firewall access for BIND
   community.general.ufw:
     rule: allow
-    proto: "{{ port.split('/') | last }}"
-    port: "{{ port.split('/') | first }}"
-    comment: Allow DNS
+    proto: "{{ port.proto }}"
+    port: "{{ port.port }}"
+    comment: "Allow {{ port.name }} to BIND"
   loop:
-    - "{{ bind_port_dns }}/udp"
-    - "{{ bind_port_dns }}/tcp"
+    - name: DNS
+      port: "{{ bind_port }}"
+      proto: udp
+      enable: true
+    - name: DNS
+      port: "{{ bind_port }}"
+      proto: tcp
+      enable: true
+    - name: DNS-over-HTTPS
+      port: "{{ bind_doh_port }}"
+      proto: tcp
+      enable: "{{ bind_doh_port }}"
+    - name: DNS-over-TLS
+      port: "{{ bind_dot_port }}"
+      proto: tcp
+      enable: "{{ bind_dot_port }}"
+  when: port.enable | bool
   loop_control:
-    label: >-
-      allow from any to {{ port }}
+    label: allow from any to {{ port.port }}/{{ port.proto }} ({{ port.name }})
     loop_var: port
   tags:
     - bind

--- a/roles/bind/tasks/service.yaml
+++ b/roles/bind/tasks/service.yaml
@@ -12,3 +12,16 @@
     - bind
     - systemd
     - service
+
+- name: Enable the Lego certificate renewal timer
+  ansible.builtin.systemd:
+    name: "lego@{{ bind_service_name }}.timer"
+    enabled: true
+    state: started
+  when: >-
+    ( bind_doh_enable or bind_dot_enable ) and
+    not ansible_check_mode
+  tags:
+    - bind
+    - systemd
+    - service

--- a/roles/bind/templates/lego.conf.jinja
+++ b/roles/bind/templates/lego.conf.jinja
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+
+LEGO_CERT_DOMAINS={{ ansible_facts.fqdn }}
+{%- for address in ansible_facts.all_ipv6_addresses %}
+{%-   if address is not regex('^fe80::') %}
+ {{ address }}
+{%-   endif %}
+{%- endfor %}
+{%- for address in ansible_facts.all_ipv4_addresses %}
+{%-   if address != '127.0.0.1' %}
+ {{ address }}
+{%-   endif %}
+{%- endfor %}
+
+LEGO_RENEW_HOOK={{ lego_usr_path }}/{{ bind_service_name }}

--- a/roles/bind/templates/lego.sh.jinja
+++ b/roles/bind/templates/lego.sh.jinja
@@ -21,7 +21,7 @@ for cert in \
   echo "$(date +'%Y/%m/%d %H:%M:%S') [INFO] Copying ${cert/=*/} to ${cert/*=/} (via ${tmp})"
 
   cp "${cert/=*/}" "${tmp}"
-  chown "named:named" "${tmp}"
+  chown "{{ bind_service_user }}:{{ bind_service_group }}" "${tmp}"
   chmod 0600 "${tmp}"
   mv -f "${tmp}" "${cert/*=/}"
 done

--- a/roles/bind/templates/lego.sh.jinja
+++ b/roles/bind/templates/lego.sh.jinja
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# {{ ansible_managed }}
+
+set -euo pipefail
+
+# Ensure required environment variables are set
+: "${LEGO_HOOK_CERT_PATH:?LEGO_HOOK_CERT_PATH must be set}"
+: "${LEGO_HOOK_CERT_KEY_PATH:?LEGO_HOOK_CERT_KEY_PATH must be set}"
+
+# Check if certificate files exist
+if [[ ! -f "${LEGO_HOOK_CERT_PATH}" || ! -f "${LEGO_HOOK_CERT_KEY_PATH}" ]]; then
+  echo "$(date +'%Y/%m/%d %H:%M:%S') [ERROR] Certificate files not found. Cannot continue." >&2
+  exit 1
+fi
+
+for cert in \
+  "${LEGO_HOOK_CERT_PATH}={{ bind_var_path }}/certs/server.crt" \
+  "${LEGO_HOOK_CERT_KEY_PATH}={{ bind_var_path }}/certs/server.key"; do
+  tmp="${cert/*=/}.tmp.${$}"
+
+  echo "$(date +'%Y/%m/%d %H:%M:%S') [INFO] Copying ${cert/=*/} to ${cert/*=/} (via ${tmp})"
+
+  cp "${cert/=*/}" "${tmp}"
+  chown "named:named" "${tmp}"
+  chmod 0600 "${tmp}"
+  mv -f "${tmp}" "${cert/*=/}"
+done
+
+echo "$(date +'%Y/%m/%d %H:%M:%S') [INFO] Reloading the BIND service ({{ bind_service_name }}.service)"
+
+systemctl reload "{{ bind_service_name }}.service"

--- a/roles/bind/templates/named.conf.jinja
+++ b/roles/bind/templates/named.conf.jinja
@@ -5,8 +5,26 @@ options {
   pid-file "{{ bind_run_path }}/named.pid";
   version "0.0.0"; // Hide the version of BIND for security reasons
 
-  listen-on port {{ bind_port_dns }} { {{ bind_listen_ipv4_addresses | join('; ') }}; };
-  listen-on-v6 port {{ bind_port_dns }} { {{ bind_listen_ipv6_addresses | join('; ') }}; };
+{%  if bind_listen_ipv4_addresses | length > 0 %}
+  listen-on port {{ bind_port }} { {{ bind_listen_ipv4_addresses | join('; ') }}; };
+{%    if bind_doh_enable %}
+  listen-on port {{ bind_doh_port }} tls {{ ansible_facts.fqdn | split('.') | reverse | join('-') }}-tls http default { {{ bind_listen_ipv4_addresses | join('; ') }}; };
+{%    endif %}
+{%    if bind_dot_enable %}
+  listen-on port {{ bind_dot_port }} tls {{ ansible_facts.fqdn | split('.') | reverse | join('-') }}-tls { {{ bind_listen_ipv4_addresses | join('; ') }}; };
+{%    endif %}
+{%  endif %}
+{%  if bind_listen_ipv6_addresses | length > 0 %}
+  listen-on-v6 port {{ bind_port }} { {{ bind_listen_ipv6_addresses | join('; ') }}; };
+{%    if bind_doh_enable %}
+  listen-on-v6 port {{ bind_doh_port }} tls {{ ansible_facts.fqdn | split('.') | reverse | join('-') }}-tls http default { {{ bind_listen_ipv6_addresses | join('; ') }}; };
+{%    endif %}
+{%    if bind_dot_enable %}
+  listen-on-v6 port {{ bind_dot_port }} tls {{ ansible_facts.fqdn | split('.') | reverse | join('-') }}-tls { {{ bind_listen_ipv6_addresses | join('; ') }}; };
+{%    endif %}
+{%  endif %}
+
+  allow-query { any; };
 
   recursion yes;
   allow-recursion { recursive-hosts-acl; };
@@ -24,7 +42,11 @@ options {
 {%  endif %}
 
   forward only;
+{%  if not bind_forwarders_dot_enable %}
   forwarders {
+{%  else %}
+  forwarders port {{ bind_forwarders_dot_port }} tls {{ bind_forwarders_dot_name | split('.') | reverse | join('-') }}-tls {
+{%  endif %}
 {%  for forwarder in bind_forwarders %}
     {{ forwarder }};
 {%  endfor %}
@@ -32,6 +54,23 @@ options {
 
   dnssec-validation {{ bind_dnssec_validation }};
 };
+{%  if bind_doh_enable or bind_dot_enable %}
+
+tls {{ ansible_facts.fqdn | split('.') | reverse | join('-') }}-tls {
+  cert-file "{{ bind_var_path }}/certs/server.crt";
+  key-file "{{ bind_var_path }}/certs/server.key";
+};
+{%  endif %}
+{%  if bind_forwarders_dot_enable %}
+
+tls {{ bind_forwarders_dot_name | split('.') | reverse | join('-') }}-tls {
+  remote-hostname "{{ bind_forwarders_dot_name }}";
+  ca-file "{{ bind_var_path }}/certs/ca.pem";
+  protocols { TLSv1.3; };
+  prefer-server-ciphers yes;
+  session-tickets yes;
+};
+{%  endif %}
 
 acl recursive-hosts-acl {
   // Always support the loopback interface for recursive queries
@@ -442,7 +481,7 @@ logging {
   };
 
   channel general-log {
-    file "{{ bind_log_path }}/named.log" versions 3 size 32m;
+    file "{{ bind_log_path }}/named.log" versions 3 size 8m;
     print-time yes;
     print-category yes;
     print-severity yes;
@@ -476,7 +515,7 @@ logging {
   category dnssec { dnssec-log; debug-log; };
 
   channel security-log {
-    file "{{ bind_log_path }}/security.log" versions 3 size 16m;
+    file "{{ bind_log_path }}/security.log" versions 3 size 4m;
     print-time yes;
     print-category yes;
     print-severity yes;
@@ -487,7 +526,7 @@ logging {
   category update-security { security-log; debug-log; };
 
   channel client-log {
-    file "{{ bind_log_path }}/client.log" versions 3 size 4m;
+    file "{{ bind_log_path }}/client.log" versions 7 size 32m;
     print-time yes;
     print-category yes;
     print-severity yes;
@@ -497,7 +536,7 @@ logging {
   category client { client-log; debug-log; };
 
   channel xfer-log {
-    file "{{ bind_log_path }}/xfer.log" versions 3 size 16m;
+    file "{{ bind_log_path }}/xfer.log" versions 3 size 4m;
     print-time yes;
     print-category yes;
     print-severity yes;

--- a/roles/lego/defaults/main.yaml
+++ b/roles/lego/defaults/main.yaml
@@ -7,3 +7,5 @@ lego_acme_email: admin@{{ ansible_facts.fqdn | default('localhost') }}
 lego_acme_servers_group: ca
 
 lego_cert_key_type: ec384
+
+lego_firewall_ipv4_replace: {}

--- a/roles/lego/tasks/firewall.yaml
+++ b/roles/lego/tasks/firewall.yaml
@@ -4,16 +4,23 @@
 - name: Enable IPv4 firewall access for {{ host }}
   community.general.ufw:
     rule: allow
-    from_ip: "{{ address }}"
+    from_ip: "{{ lego_firewall_ipv4_replace[address] | default(address) }}"
     proto: tcp
     port: "{{ lego_listen_http }}"
     comment: >-
       Allow HTTP-01 ACME for Lego from {{ host }}
+  when: >-
+    lego_firewall_ipv4_replace[address] is not defined or
+    lego_firewall_ipv4_replace[address] != "skipped"
   loop: >-
     {{ hostvars[host].ansible_facts.all_ipv4_addresses }}
   loop_control:
     label: >-
-      allow from {{ address }} to {{ lego_listen_http }}/tcp
+      allow from {{ address }}
+      {% if lego_firewall_ipv4_replace[address] is defined -%}
+      ({{ lego_firewall_ipv4_replace[address] | default(address) }})
+      {% endif -%}
+      to {{ lego_listen_http }}/tcp
     loop_var: address
 
 - name: Enable IPv6 firewall access for {{ host }}

--- a/roles/lego/templates/defaults.conf.jinja
+++ b/roles/lego/templates/defaults.conf.jinja
@@ -10,7 +10,7 @@ LEGO_CERT_KEY_TYPE={{ lego_cert_key_type }}
 {% if lego_acme_mode == 'caddy' %}
 LEGO_ACME_MODE=webroot={{ lego_srv_path }}
 {% else %}
-LEGO_ACME_MODE=port={{ lego_listen_http }}
+LEGO_ACME_MODE=address=:{{ lego_listen_http }}
 {% endif %}
 
 LEGO_RENEW_HOOK=


### PR DESCRIPTION
Support the running of DNS-over-HTTPS and DNS-over-TLS via BIND through Lego in the BIND playbook, and prepare the configuration for `dns- and external- hosts to enable DNS-over-TLS and DNS-over-HTTPS support. 

## Checklist

Before raising this Pull Request, please review the `CONTRIBUTING.md` document for guidance on how best to work with this repository and its code. Additionally, please review and confirm the following items have been performed, where possible:

- [x] I have performed a self-review of my code and run any tests to check
- [ ] I have run and added tests to prove my changes are effective and correctly
- [x] I have made corresponding changes to the documentation as needed
- [x] Each commit in, and this PR, have a meaningful subject and body for context
- [x] I have added `release/...` and `{update,type}/...` labels to this PR
